### PR TITLE
Add program scaffold: Makefile, includes/, srcs/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+EXEC: encode
+FILES: main
+SRCS: {$(FILES)}.c
+OBJECTS: {$(FILES)}.o
+
+all:
+	gcc -Wall -Wextra -Werror -I./includes -c $(SRCS)
+	gcc $(OBJECTS) -o $(EXEC)
+clean:
+	rm -f $(OBJECTS)
+fclean: clean
+	rm -f $(EXEC)
+re: fclean all

--- a/includes/includes.h
+++ b/includes/includes.h
@@ -1,0 +1,1 @@
+/*Dummy header file*/

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,0 +1,1 @@
+/*Dummy main file*/


### PR DESCRIPTION
I made a "scaffold" branch that serves as a scaffold for the full program - we can use it as a skeleton.  It doesn't compile right now, but it has a basic Makefile, and includes/ and srcs/ directories.
